### PR TITLE
Make sure password hashes are bytes before passing to AuthEncoding.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Change Log
 2.0b3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Handle password hashes that were accidentally decoded.
 
 
 2.0b2 (2018-10-16)

--- a/Products/PluggableAuthService/plugins/ZODBUserManager.py
+++ b/Products/PluggableAuthService/plugins/ZODBUserManager.py
@@ -125,6 +125,8 @@ class ZODBUserManager(BasePlugin, Cacheable):
             return None
 
         reference = self._user_passwords.get(userid)
+        if isinstance(reference, six.text_type):
+            reference = reference.encode('utf8')
 
         if reference is None:
             return None


### PR DESCRIPTION
This isn't ideal, but works around the fact that they can end up accidentally decoded while converting a database to Python 3.
It's difficult to target values in BTrees for special handling by zodbupdate since you don't know which BTree you're working on.