### PR TITLE
Replace deprecated and removed `im_self` with `__self__`.

### DIFF
--- a/Products/PluggableAuthService/PluggableAuthService.py
+++ b/Products/PluggableAuthService/PluggableAuthService.py
@@ -884,10 +884,10 @@ class PluggableAuthService(Folder, Cacheable):
             # this is not a method, we needn't treat it specially
             c = innerparent
 
-        elif hasattr(v, 'im_self'):
+        elif hasattr(v, '__self__'):
 
             # this is a method, we need to treat it specially
-            c = v.im_self
+            c = v.__self__
             c = aq_inner(v)
 
         # if pub's aq_parent or container is the request container, it

--- a/Products/PluggableAuthService/PropertiedUser.py
+++ b/Products/PluggableAuthService/PropertiedUser.py
@@ -126,7 +126,7 @@ class PropertiedUser(BasicUser):
                 object = parent
                 continue
 
-            new = getattr(object, 'im_self', None)
+            new = getattr(object, '__self__', None)
 
             if new is not None:
 
@@ -222,7 +222,7 @@ class PropertiedUser(BasicUser):
                 inner_obj = parent
                 continue
 
-            new = getattr(inner_obj, 'im_self', None)
+            new = getattr(inner_obj, '__self__', None)
 
             if new is not None:
                 inner_obj = aq_inner(new)

--- a/Products/PluggableAuthService/tests/test_PluggableAuthService.py
+++ b/Products/PluggableAuthService/tests/test_PluggableAuthService.py
@@ -1107,6 +1107,32 @@ class PluggableAuthServiceTests(unittest.TestCase, IUserFolder_conformance,
         self.assertEqual(n, 'index_html')
         self.assertEqual(v, published)
 
+    def test__getObjectContext_method(self):
+        """It also works with a method on the object."""
+        zcuf = self._makeOne()
+
+        rc, root, folder, object = self._makeTree()
+
+        def faux_method(self):
+            pass
+
+        FauxObject.meth = faux_method
+        local_index = FauxObject('index_html').__of__(object)
+
+        request = self._makeRequest(
+            ('folder', 'object', 'index_html', 'meth'),
+            RESPONSE=FauxResponse(),
+            PARENTS=[local_index, object, folder, root])
+
+        published = local_index.meth
+
+        a, c, n, v = zcuf._getObjectContext(published, request)
+
+        self.assertEqual(a, local_index)
+        self.assertEqual(c, published)
+        self.assertEqual(n, 'meth')
+        self.assertEqual(v, published)
+
     def test__getObjectContext_acquired_from_folder(self):
 
         zcuf = self._makeOne()

--- a/Products/PluggableAuthService/tests/test_PropertiedUser.py
+++ b/Products/PluggableAuthService/tests/test_PropertiedUser.py
@@ -19,12 +19,12 @@ from .conformance import IBasicUser_conformance
 from .conformance import IPropertiedUser_conformance
 
 
-class FauxMethod:
+def faux_method(self, x):
+    """Just a faux function object with local roles defined later."""
+    return None
 
-    def __init__(self, im_self, local_roles=()):
 
-        self.im_self = im_self
-        self.__ac_local_roles__ = local_roles
+faux_method.__ac_local_roles__ = {'Group C': ('Manager', 'Owner')}
 
 
 class FauxProtected(Implicit):
@@ -183,10 +183,10 @@ class PropertiedUserTests(unittest.TestCase, IBasicUser_conformance,
         user = self._makeOne()
         user._addGroups(groups)
 
+        FauxProtected.method = faux_method
         faux_self = FauxProtected({'Group A': ('Manager',)})
-        faux_method = FauxMethod(faux_self, {'Group C': ('Manager', 'Owner')})
 
-        local_roles = user.getRolesInContext(faux_method)
+        local_roles = user.getRolesInContext(faux_self.method)
         self.assertEqual(len(local_roles), 1)
         self.assertTrue('Manager' in local_roles)
 
@@ -271,10 +271,10 @@ class PropertiedUserTests(unittest.TestCase, IBasicUser_conformance,
         user = self._makeOne()
         user._addGroups(groups)
 
+        FauxProtected.method = faux_method
         faux_self = FauxProtected({'Group A': ('Manager',)})
-        faux_method = FauxMethod(faux_self, {'Group C': ('Manager', 'Owner')})
 
-        self.assertTrue(user.allowed(faux_method, ('Manager',)))
+        self.assertTrue(user.allowed(faux_self.method, ('Manager',)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`im_self` was removed in Python 3, but the tests included to may faux assumptions to fail at the API change. 

I am not sure, whether I did the right thing with the test in https://github.com/zopefoundation/Products.PluggableAuthService/commit/549e69f8abcb581ad7a5635c0fdb53942a9f1aa9, but at least the code path is now executed.