### PR TITLE
Fix bug in `getRolesForPrincipal` for non PAS user.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Change Log
 2.2 (unreleased)
 ----------------
 
+- Fix bug in ``getRolesForPrincipal`` for non PAS user.
+
 
 2.1 (2019-08-29)
 ----------------

--- a/Products/PluggableAuthService/plugins/ZODBRoleManager.py
+++ b/Products/PluggableAuthService/plugins/ZODBRoleManager.py
@@ -106,7 +106,7 @@ class ZODBRoleManager(BasePlugin):
         """
         result = list(self._principal_roles.get(principal.getId(), ()))
 
-        getGroups = getattr(principal, 'getGroups', lambda x: ())
+        getGroups = getattr(principal, 'getGroups', lambda: ())
         for group_id in getGroups():
             result.extend(self._principal_roles.get(group_id, ()))
 

--- a/Products/PluggableAuthService/plugins/tests/test_ZODBRoleManager.py
+++ b/Products/PluggableAuthService/plugins/tests/test_ZODBRoleManager.py
@@ -13,6 +13,7 @@
 ##############################################################################
 import unittest
 
+from AccessControl.users import SpecialUser
 from zExceptions import Forbidden
 
 from Products.PluggableAuthService.plugins.tests.helpers import DummyUser
@@ -51,6 +52,21 @@ class ZODBRoleManagerTests(unittest.TestCase, IRolesPlugin_conformance,
         self.assertEqual(len(zrm.enumerateRoles()), 0)
 
         user = DummyUser('userid')
+        roles = zrm.getRolesForPrincipal(user)
+        self.assertEqual(len(roles), 0)
+
+    def test_zope_user(self):
+        """It does not break `getRolesForPrincipal` in case of a zope user
+
+        which has no `getGroups`.
+        """
+        zrm = self._makeOne()
+
+        self.assertEqual(len(zrm.listRoleIds()), 0)
+        self.assertEqual(len(zrm.enumerateRoles()), 0)
+
+        # This user has no `getGroups()` as the typical PAS user.
+        user = SpecialUser('admin', 'admin', ['Manager'], None)
         roles = zrm.getRolesForPrincipal(user)
         self.assertEqual(len(roles), 0)
 


### PR DESCRIPTION
It broke for user objects which do not implement `getGroups` as the lambda function is called without arguments.