### PR TITLE
Fix ICredentialsUpdatedEvent event handler incorrectly calls updateCredentials

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,12 +4,15 @@ Change Log
 2.3 (unreleased)
 ----------------
 
+- Fix ICredentialsUpdatedEvent event handler incorrectly calls updateCredentials.
+  (`#17 <https://github.com/zopefoundation/Products.PluggableAuthService/issues/59>`_)
+
 
 2.2 (2019-11-23)
 ----------------
 
 - Add new events to be able to notify when a principal is added to
-  or removed from a group. Notify these events when principals are 
+  or removed from a group. Notify these events when principals are
   added or removed to a group in ZODBGroupManager
   (`#17 <https://github.com/zopefoundation/Products.PluggableAuthService/issues/17>`_)
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Change Log
 2.3 (unreleased)
 ----------------
 
-- Fix ICredentialsUpdatedEvent event handler incorrectly calls updateCredentials.
+- Fix broken ICredentialsUpdatedEvent event handler call to updateCredentials.
   (`#17 <https://github.com/zopefoundation/Products.PluggableAuthService/issues/59>`_)
 
 

--- a/Products/PluggableAuthService/events.py
+++ b/Products/PluggableAuthService/events.py
@@ -101,7 +101,6 @@ class PropertiesUpdated(PASEvent):
 def userCredentialsUpdatedHandler(principal, event):
     pas = aq_parent(principal)
     pas.updateCredentials(
-            pas,
             pas.REQUEST,
             pas.REQUEST.RESPONSE,
             principal.getId(),

--- a/Products/PluggableAuthService/tests/test_UserFolder.py
+++ b/Products/PluggableAuthService/tests/test_UserFolder.py
@@ -325,6 +325,7 @@ class UserEvents(pastc.PASTestCase):
         self.assertEqual(event.principal.getId(), 'event1')
 
     def testCredentialsEvent(self):
+        import functools
         provideHandler(PASEventNotify)
         provideHandler(userCredentialsUpdatedHandler)
 
@@ -334,7 +335,7 @@ class UserEvents(pastc.PASTestCase):
 
         self.uf._data = []
         self.uf._original = self.uf.updateCredentials
-        self.uf.updateCredentials = wrap
+        self.uf.updateCredentials = functools.partial(wrap, self.uf)
         self.assertEqual(len(self.uf._data), 0)
         event.notify(CredentialsUpdated(self.uf.getUserById('user1'),
                                         'testpassword'))


### PR DESCRIPTION
Fixes #59 

* Fixed userCredentialsUpdatedHandler: Now calls updateCredentials without passing pas as first argument.
* Fixed updateCredentials test.