### PR TITLE
Fix linting issue

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -63,8 +63,8 @@ commands_pre =
     mkdir -p {toxinidir}/parts/flake8
 commands =
     isort --check-only --diff --recursive {toxinidir}/Products setup.py
-    - flake8 --format=html Products tests setup.py {posargs}
-    flake8 Products tests setup.py {posargs}
+    - flake8 --format=html Products setup.py {posargs}
+    flake8 Products setup.py {posargs}
 deps =
     isort
     flake8


### PR DESCRIPTION
... which arise with the new flake8 version.

`tests` is no longer a valid flake8 param, as it is no top level
directory.

As it is a subfolder of the `src` folder, it gets linted anyway.

modified:   tox.ini