### PR TITLE
Security cleanups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Change Log
 2.6.0 (unreleased)
 ------------------
 
+- Fix missing access control on ZODB Role Manager ``enumerateRoles``
+
 - Fix open redirect issue in `Cookie Auth Helper` redirect handling
 
 - Add support for Python 3.9.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Change Log
 2.6.0 (unreleased)
 ------------------
 
+- Fix open redirect issue in `Cookie Auth Helper` redirect handling
+
 - Add support for Python 3.9.
 
 

--- a/src/Products/PluggableAuthService/plugins/CookieAuthHelper.py
+++ b/src/Products/PluggableAuthService/plugins/CookieAuthHelper.py
@@ -28,6 +28,8 @@ from binascii import hexlify
 import six
 from six.moves.urllib.parse import quote
 from six.moves.urllib.parse import unquote
+from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urlunparse
 
 from AccessControl.class_init import InitializeClass
 from AccessControl.Permissions import view
@@ -224,6 +226,12 @@ class CookieAuthHelper(Folder, BasePlugin):
                     # the only sane thing to do is to give up because we are
                     # in an endless redirect loop.
                     return 0
+
+            # Sanitize the return URL ``came_from`` and only allow local URLs
+            # to prevent an open exploitable redirect issue
+            if came_from:
+                parsed = urlparse(came_from)
+                came_from = urlunparse(('', '') + parsed[2:])
 
             if '?' in url:
                 sep = '&'

--- a/src/Products/PluggableAuthService/plugins/ZODBRoleManager.py
+++ b/src/Products/PluggableAuthService/plugins/ZODBRoleManager.py
@@ -112,6 +112,7 @@ class ZODBRoleManager(BasePlugin):
     #
     #   IRoleEnumerationPlugin implementation
     #
+    @security.private
     def enumerateRoles(self, id=None, exact_match=False, sort_by=None,
                        max_results=None, **kw):
         """ See IRoleEnumerationPlugin.

--- a/src/Products/PluggableAuthService/plugins/tests/test_CookieAuthHelper.py
+++ b/src/Products/PluggableAuthService/plugins/tests/test_CookieAuthHelper.py
@@ -20,7 +20,6 @@ import codecs
 import unittest
 
 import six
-from six.moves.urllib.parse import quote
 
 from ...tests.conformance import IChallengePlugin_conformance
 from ...tests.conformance import ICredentialsResetPlugin_conformance
@@ -128,7 +127,7 @@ class CookieAuthHelperTests(unittest.TestCase,
     def test_challenge(self):
         rc, root, folder, object = self._makeTree()
         response = FauxCookieResponse()
-        testPath = '/some/path'
+        testPath = '/some/path?arg1=val1&arg2=val2'
         testURL = 'http://test' + testPath
         request = FauxRequest(RESPONSE=response, URL=testURL,
                               ACTUAL_URL=testURL)
@@ -139,9 +138,9 @@ class CookieAuthHelperTests(unittest.TestCase,
         helper.challenge(request, response)
         self.assertEqual(response.status, 302)
         self.assertEqual(len(response.headers), 3)
-        loc = response.headers['Location']
-        self.assertTrue(loc.endswith(quote(testPath)))
-        self.assertNotIn(testURL, loc)
+        self.assertEqual(
+            response.headers['Location'],
+            '/login_form?came_from=/some/path%3Farg1%3Dval1%26arg2%3Dval2')
         self.assertEqual(response.headers['Cache-Control'], 'no-cache')
         self.assertEqual(response.headers['Expires'],
                          'Sat, 01 Jan 2000 00:00:00 GMT')
@@ -150,7 +149,7 @@ class CookieAuthHelperTests(unittest.TestCase,
         rc, root, folder, object = self._makeTree()
         response = FauxCookieResponse()
         vhm = 'http://localhost/VirtualHostBase/http/test/VirtualHostRoot/xxx'
-        actualURL = 'http://test/xxx'
+        actualURL = 'http://test/xxx?arg1=val1&arg2=val2'
 
         request = FauxRequest(RESPONSE=response, URL=vhm,
                               ACTUAL_URL=actualURL)
@@ -161,10 +160,9 @@ class CookieAuthHelperTests(unittest.TestCase,
         helper.challenge(request, response)
         self.assertEqual(response.status, 302)
         self.assertEqual(len(response.headers), 3)
-        loc = response.headers['Location']
-        self.assertTrue(loc.endswith(quote('/xxx')))
-        self.assertFalse(loc.endswith(quote(vhm)))
-        self.assertNotIn(actualURL, loc)
+        self.assertEqual(
+            response.headers['Location'],
+            '/login_form?came_from=/xxx%3Farg1%3Dval1%26arg2%3Dval2')
         self.assertEqual(response.headers['Cache-Control'], 'no-cache')
         self.assertEqual(response.headers['Expires'],
                          'Sat, 01 Jan 2000 00:00:00 GMT')

--- a/src/Products/PluggableAuthService/plugins/tests/test_CookieAuthHelper.py
+++ b/src/Products/PluggableAuthService/plugins/tests/test_CookieAuthHelper.py
@@ -128,7 +128,8 @@ class CookieAuthHelperTests(unittest.TestCase,
     def test_challenge(self):
         rc, root, folder, object = self._makeTree()
         response = FauxCookieResponse()
-        testURL = 'http://test'
+        testPath = '/some/path'
+        testURL = 'http://test' + testPath
         request = FauxRequest(RESPONSE=response, URL=testURL,
                               ACTUAL_URL=testURL)
         root.REQUEST = request
@@ -138,7 +139,9 @@ class CookieAuthHelperTests(unittest.TestCase,
         helper.challenge(request, response)
         self.assertEqual(response.status, 302)
         self.assertEqual(len(response.headers), 3)
-        self.assertTrue(response.headers['Location'].endswith(quote(testURL)))
+        loc = response.headers['Location']
+        self.assertTrue(loc.endswith(quote(testPath)))
+        self.assertNotIn(testURL, loc)
         self.assertEqual(response.headers['Cache-Control'], 'no-cache')
         self.assertEqual(response.headers['Expires'],
                          'Sat, 01 Jan 2000 00:00:00 GMT')
@@ -159,8 +162,9 @@ class CookieAuthHelperTests(unittest.TestCase,
         self.assertEqual(response.status, 302)
         self.assertEqual(len(response.headers), 3)
         loc = response.headers['Location']
-        self.assertTrue(loc.endswith(quote(actualURL)))
+        self.assertTrue(loc.endswith(quote('/xxx')))
         self.assertFalse(loc.endswith(quote(vhm)))
+        self.assertNotIn(actualURL, loc)
         self.assertEqual(response.headers['Cache-Control'], 'no-cache')
         self.assertEqual(response.headers['Expires'],
                          'Sat, 01 Jan 2000 00:00:00 GMT')


### PR DESCRIPTION
This PR is a response to two security issues flagged up to the Plone security list (security@plone.org):

- The Cookie Auth Helper doesn't do any input checking on the `came_from` URL and allows everything, including URLs with different hostnames. It's an open redirect: https://cwe.mitre.org/data/definitions/601.html. The PR fixes it by always removing the protocol and host parts before doing the redirect, thereby limiting the redirect to the site that showed the login form.
- The `enumerateRoles` method on the ZODB Role Manager had no permission assigned to it, making it accessible for everyone, inclusing anonymous visitors. That's is an information disclosure vulnerability. This PR declares the method private, like all other `enumerateXXX` methods on the other plugins. 