### PR TITLE
Tighten down security on several login string transformation methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Change Log
 2.6.2 (unreleaased)
 -------------------
 
+- Tighten down security on several login string transformation methods
+  (`#88
+  <https://github.com/zopefoundation/Products.PluggableAuthService/issues/88>`_)
+
 
 2.6.1 (2021-02-26)
 ------------------

--- a/src/Products/PluggableAuthService/PluggableAuthService.py
+++ b/src/Products/PluggableAuthService/PluggableAuthService.py
@@ -976,7 +976,7 @@ class PluggableAuthService(Folder, Cacheable):
         resp._unauthorized = self._unauthorized
         resp._has_challenged = False
 
-    @security.public
+    @security.private
     def applyTransform(self, value):
         """ Transform for login name.
 
@@ -1024,7 +1024,7 @@ class PluggableAuthService(Folder, Cacheable):
                          'Updating existing login names.', orig_value, value)
             self.updateAllLoginNames()
 
-    @security.public
+    @security.private
     def lower(self, value):
         """ Transform for login name.
 
@@ -1034,7 +1034,7 @@ class PluggableAuthService(Folder, Cacheable):
         """
         return value.strip().lower()
 
-    @security.public
+    @security.private
     def upper(self, value):
         """ Transform for login name.
 

--- a/src/Products/PluggableAuthService/plugins/BasePlugin.py
+++ b/src/Products/PluggableAuthService/plugins/BasePlugin.py
@@ -115,7 +115,7 @@ class BasePlugin(SimpleItem, PropertyManager):
             view_name = createViewName('_findUser', id)
             pas.ZCacheable_invalidate(view_name)
 
-    @security.public
+    @security.private
     def applyTransform(self, value):
         """ Transform for login name.
 


### PR DESCRIPTION
Fixes #88 

None of the involved methods need to be public, they are all only used internally from what I can tell.