### PR TITLE
make cookie based login more robust

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Change Log
 ------------------
 - Changed adding object gui to modal window
 
+- Handle login issues for cookie based login when ``came_from`` is missing
+  (`#65
+  <https://github.com/zopefoundation/Products.PluggableAuthService/issues/65>`_)
+
 2.6.2 (2021-03-12)
 -------------------
 

--- a/src/Products/PluggableAuthService/plugins/CookieAuthHelper.py
+++ b/src/Products/PluggableAuthService/plugins/CookieAuthHelper.py
@@ -275,10 +275,18 @@ class CookieAuthHelper(Folder, BasePlugin):
 
         if pas_instance is not None:
             pas_instance.updateCredentials(request, response, login, password)
-
-        came_from = url_local(request.form['came_from'])
-
-        return response.redirect(came_from)
+        came_from = request.form.get('came_from')
+        if came_from is not None:
+            return response.redirect(url_local(came_from))
+        # When this happens, this either means
+        # - the administrator did not setup the login form properly
+        # - the user manipulated the login form and removed `came_from`
+        # Still, the user provided correct credentials and is logged in.
+        return (
+            '<h1>You have been logged in successfully.</h1>\n'
+            '<p>Unfortunately, we do not know where to redirect you to.</p>'
+            '<p>If you need help, please ask the site\'s administrator.</p>'
+        )
 
 
 classImplements(CookieAuthHelper, ICookieAuthHelper,

--- a/src/Products/PluggableAuthService/plugins/CookieAuthHelper.py
+++ b/src/Products/PluggableAuthService/plugins/CookieAuthHelper.py
@@ -32,6 +32,8 @@ from six.moves.urllib.parse import unquote
 from AccessControl.class_init import InitializeClass
 from AccessControl.Permissions import view
 from AccessControl.SecurityInfo import ClassSecurityInfo
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from OFS.Folder import Folder
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
@@ -282,11 +284,8 @@ class CookieAuthHelper(Folder, BasePlugin):
         # - the administrator did not setup the login form properly
         # - the user manipulated the login form and removed `came_from`
         # Still, the user provided correct credentials and is logged in.
-        return (
-            '<h1>You have been logged in successfully.</h1>\n'
-            '<p>Unfortunately, we do not know where to redirect you to.</p>'
-            '<p>If you need help, please ask the site\'s administrator.</p>'
-        )
+        pas_root = aq_parent(aq_inner(self._getPAS()))
+        return response.redirect(pas_root.absolute_url())
 
 
 classImplements(CookieAuthHelper, ICookieAuthHelper,

--- a/src/Products/PluggableAuthService/plugins/tests/test_CookieAuthHelper.py
+++ b/src/Products/PluggableAuthService/plugins/tests/test_CookieAuthHelper.py
@@ -211,14 +211,6 @@ class CookieAuthHelperTests(unittest.TestCase,
         helper.login()
         self.assertEqual(len(response.cookies), 0)
 
-    def test_login_with_missing_came_from(self):
-        helper = self._makeOne()
-        response = FauxCookieResponse()
-        request = FauxSettableRequest(RESPONSE=response)
-        helper.REQUEST = request
-        rv = helper.login()
-        self.assertIn('You have been logged in successfully.', rv)
-
     def test_extractCredentials_from_cookie_with_colon_in_password(self):
         # http://www.zope.org/Collectors/PAS/51
         # Passwords with ":" characters broke authentication

--- a/src/Products/PluggableAuthService/plugins/tests/test_CookieAuthHelper.py
+++ b/src/Products/PluggableAuthService/plugins/tests/test_CookieAuthHelper.py
@@ -22,11 +22,11 @@ import unittest
 import six
 
 from ...interfaces.plugins import IChallengePlugin
+from ...tests import pastc
 from ...tests.conformance import IChallengePlugin_conformance
 from ...tests.conformance import ICredentialsResetPlugin_conformance
 from ...tests.conformance import ICredentialsUpdatePlugin_conformance
 from ...tests.conformance import ILoginPasswordHostExtractionPlugin_conformance
-from ...tests import pastc
 from ...tests.test_PluggableAuthService import FauxContainer
 from ...tests.test_PluggableAuthService import FauxObject
 from ...tests.test_PluggableAuthService import FauxRequest

--- a/src/Products/PluggableAuthService/plugins/tests/test_CookieAuthHelper.py
+++ b/src/Products/PluggableAuthService/plugins/tests/test_CookieAuthHelper.py
@@ -211,6 +211,14 @@ class CookieAuthHelperTests(unittest.TestCase,
         helper.login()
         self.assertEqual(len(response.cookies), 0)
 
+    def test_login_with_missing_came_from(self):
+        helper = self._makeOne()
+        response = FauxCookieResponse()
+        request = FauxSettableRequest(RESPONSE=response)
+        helper.REQUEST = request
+        rv = helper.login()
+        self.assertIn('You have been logged in successfully.', rv)
+
     def test_extractCredentials_from_cookie_with_colon_in_password(self):
         # http://www.zope.org/Collectors/PAS/51
         # Passwords with ":" characters broke authentication


### PR DESCRIPTION
The login did not work when `came_from` request parameter was missing.

This is now handled gracefully, as the user, who provided correct
credentials, now gets logged in and gets notified about the next steps.

This fixes #65