### PR TITLE
Pass user name as login to updateCredentials - fix #105

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Change Log
 2.6.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Pass the login name as ``updateCredentials``'s ``login`` parameter
+  (not the user id) (`#105 
+  <https://github.com/zopefoundation/Products.PluggableAuthService/issues/105>`_).
+  Fix docstring of ``PluggableAuthService._extractUserIds``.
 
 
 2.6.4 (2021-07-28)

--- a/src/Products/PluggableAuthService/PluggableAuthService.py
+++ b/src/Products/PluggableAuthService/PluggableAuthService.py
@@ -531,11 +531,11 @@ class PluggableAuthService(Folder, Cacheable):
 
     @security.private
     def _extractUserIds(self, request, plugins):
-        """ request -> [validated_user_id]
+        """ request -> [(validated_user_id, login)]
 
         o For each set of extracted credentials, try to authenticate
-          a user;  accumulate a list of the IDs of such users over all
-          our authentication and extraction plugins.
+          a user;  accumulate a list of pairs (ID, login) of such users
+          over all our authentication and extraction plugins.
         """
         try:
             extractors = plugins.listPlugins(IExtractionPlugin)

--- a/src/Products/PluggableAuthService/events.py
+++ b/src/Products/PluggableAuthService/events.py
@@ -97,7 +97,7 @@ def userCredentialsUpdatedHandler(principal, event):
     pas.updateCredentials(
         pas.REQUEST,
         pas.REQUEST.RESPONSE,
-        principal.getId(),
+        principal.getUserName(), # aka "login"
         event.password)
 
 

--- a/src/Products/PluggableAuthService/events.py
+++ b/src/Products/PluggableAuthService/events.py
@@ -97,7 +97,7 @@ def userCredentialsUpdatedHandler(principal, event):
     pas.updateCredentials(
         pas.REQUEST,
         pas.REQUEST.RESPONSE,
-        principal.getUserName(), # aka "login"
+        principal.getUserName(),  # aka "login"
         event.password)
 
 

--- a/src/Products/PluggableAuthService/tests/pastc.py
+++ b/src/Products/PluggableAuthService/tests/pastc.py
@@ -57,6 +57,8 @@ class PASTestCase(ZopeTestCase.ZopeTestCase):
         plugins.activatePlugin(IRolesPlugin, 'roles')
         plugins.activatePlugin(IRoleAssignerPlugin, 'roles')
         plugins.activatePlugin(IRoleEnumerationPlugin, 'roles')
+        # add a user for which id and login are different
+        plugins.users.addUser("user_id", "user_login", "user_password")
 
     def _setupUser(self):
         """Creates the default user."""

--- a/src/Products/PluggableAuthService/tests/test_UserFolder.py
+++ b/src/Products/PluggableAuthService/tests/test_UserFolder.py
@@ -335,7 +335,7 @@ class UserEvents(pastc.PASTestCase):
         self.uf._original = self.uf.updateCredentials
         self.uf.updateCredentials = functools.partial(wrap, self.uf)
         self.assertEqual(len(self.uf._data), 0)
-        event.notify(CredentialsUpdated(self.uf.getUserById('user1'),
+        event.notify(CredentialsUpdated(self.uf.getUserById('user_id'),
                                         'testpassword'))
-        self.assertEqual(self.uf._data[0][2], 'user1')
+        self.assertEqual(self.uf._data[0][2], 'user_login')
         self.assertEqual(self.uf._data[0][3], 'testpassword')


### PR DESCRIPTION
`updateCredentials` usually works together with `extractCredentials`. `extractCredentials` usually does not know user ids - they become only known after authentication. Therefore, the `login` parameter of `updateCredentials` must refer to the user name (which actually is the login name) and not the user id -- as the name `login` suggests.
In #105 @rpatterson  reported a violation of this condition in `events.userCredentialsUpdatedHandler`.

This PR fixes  #105.
It also fixes the docstring of `PluggableAuthService._extractUserIds`.