### PR TITLE
Improve the PAS override for Zope's `manage_zmi_logout`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change Log
 2.6.5 (unreleased)
 ------------------
 
+- Improve the PAS override for Zope's ``manage_zmi_logout`` (`#107
+  <https://github.com/zopefoundation/Products.PluggableAuthService/issues/107>`_)
+
 - Fixed deprecation warning for ``AccessControl.AuthEncoding``.
 
 - Pass the login name as ``updateCredentials``'s ``login`` parameter

--- a/src/Products/PluggableAuthService/tests/test_UserFolder.py
+++ b/src/Products/PluggableAuthService/tests/test_UserFolder.py
@@ -254,14 +254,6 @@ class UserFolderTests(pastc.PASTestCase):
 
         self.assertEqual(uid_and_info, (USER_ID, USER_ID))
 
-    def test_manage_zmi_logout(self):
-        request = self.app.REQUEST
-        response = request.RESPONSE
-        self.folder.manage_zmi_logout(request, response)
-        self.assertEqual(response.status, 401)
-        self.assertEqual(response.headers.get('WWW-Authenticate'),
-                         'basic realm="%s"' % response.realm)
-
 
 class UserTests(pastc.PASTestCase):
 

--- a/src/Products/PluggableAuthService/tests/test_zmi_logout.py
+++ b/src/Products/PluggableAuthService/tests/test_zmi_logout.py
@@ -18,7 +18,6 @@ from zope.interface import directlyProvides
 from ..interfaces.plugins import ICredentialsResetPlugin
 from ..interfaces.plugins import ICredentialsUpdatePlugin
 from ..interfaces.plugins import IExtractionPlugin
-
 from .pastc import PASTestCase
 from .pastc import user_name
 from .pastc import user_password

--- a/src/Products/PluggableAuthService/tests/test_zmi_logout.py
+++ b/src/Products/PluggableAuthService/tests/test_zmi_logout.py
@@ -1,0 +1,78 @@
+##############################################################################
+#
+# Copyright (c) 2022 Zope Foundation and Contributors
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this
+# distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+from Testing.ZopeTestCase import ZopeTestCase
+from zope.interface import directlyProvides
+
+from ..interfaces.plugins import ICredentialsResetPlugin
+from ..interfaces.plugins import ICredentialsUpdatePlugin
+from ..interfaces.plugins import IExtractionPlugin
+
+from .pastc import PASTestCase
+from .pastc import user_name
+from .pastc import user_password
+from .test_PluggableAuthService import DummyCredentialsStore
+
+
+class PasMixin(object):
+    def _setupUserFolder(self):
+        super(PasMixin, self)._setupUserFolder()
+        pas = self.folder.acl_users
+        plugins = pas.plugins
+        creds_store = DummyCredentialsStore('creds')
+        directlyProvides(creds_store, IExtractionPlugin,
+                         ICredentialsUpdatePlugin, ICredentialsResetPlugin)
+        pas._setObject('creds', creds_store)
+        plugins.deactivatePlugin(IExtractionPlugin, 'http_auth')
+        plugins.activatePlugin(IExtractionPlugin, 'creds')
+        plugins.activatePlugin(ICredentialsUpdatePlugin, 'creds')
+        plugins.activatePlugin(ICredentialsResetPlugin, 'creds')
+        request = self.folder.REQUEST
+        request["login"] = user_name
+        creds_store.updateCredentials(
+            request, request.response, user_name, user_password)
+
+    def verify_logout(self):
+        folder = self.folder
+        request = folder.REQUEST
+        return not folder.acl_users.creds.extractCredentials(request)
+
+
+class ZopeMixin(object):
+    def verify_logout(self):
+        response = self.folder.REQUEST.response
+        return response.getStatus() == 401
+
+
+class Tests(object):
+    def test_logout(self):
+        folder = self.folder
+        request = folder.REQUEST
+        folder.manage_zmi_logout(request, request.response)
+        self.assertTrue(self.verify_logout())
+
+
+class PasLogoutTests(PasMixin, Tests, PASTestCase):
+    def test_not_logged_in(self):
+        from AccessControl.SecurityManagement import noSecurityManager
+        noSecurityManager()
+        folder = self.folder
+        request = folder.REQUEST
+        self.assertEqual(
+            folder.manage_zmi_logout(request, request.response),
+            "You are not/no longer logged in")
+
+
+class ZopeLogoutTests(ZopeMixin, Tests, ZopeTestCase):
+    pass


### PR DESCRIPTION
Fixes #107 -- more precisely, tries to improve the behavior of the PAS override of Zope's `manage_zmi_logout`. But it is not complete and may even work worse then previously.

Previously, the PAS override of `manage_zmi_logout` made the (implicit) assumption that the top level user folder uses HTTP authentication. #107 demonstrates that it fails miserably when this assumption is not met.

This PR drops the assumption but it can not guarantee  full logout. The problem arises when the current request contains credentials for different user folders (e.g. manager credentials for the top level user folder and credentials for a portal's user folder). The `manage_zmi_logout` will reset the credentials for the lowest user folder in the current context (the one that authenticated the current user) provided that this user folder implements `IPluggableAuthService` (otherwise, Zope's `manage_zmi_logout` will be called which assumes HTTP authentication). If the request still contains credentials for further up user folders, then the logout will not be complete and the user must again call for a logout.

The support for HTTP authentication prevents us from performing an automated logout from all user folders in the current context because the HTTP logout requires the browser to show its login dialog and with this dialog the server loses control. We could do better in the absence of HTTP authentication (at least at the local level) but the PAS flexibility makes it hard to detect HTTP authentication reliably.