### PR TITLE
Add session auth helper property to clear session data at login boundary

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Change Log
 4.0 (unreleased)
 ----------------
 
+- Add property to clear session data at login boundary to the session auth
+  helper. This property defaults to ``False`` to preserve the current behavior.
+  Clearing session data during login helps mitigate session fixation attacks:
+  https://owasp.org/www-community/attacks/Session_fixation
+
 - Add support for Python 3.13.
 
 - Drop support for Python 3.8.

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     version=_package_doc('version.txt').strip(),
     description='Pluggable Zope authentication / authorization framework',
     long_description=README,
+    long_description_content_type='text/x-rst',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Framework :: Plone',

--- a/src/Products/PluggableAuthService/plugins/SessionAuthHelper.py
+++ b/src/Products/PluggableAuthService/plugins/SessionAuthHelper.py
@@ -16,6 +16,7 @@
 
 from AccessControl.class_init import InitializeClass
 from AccessControl.SecurityInfo import ClassSecurityInfo
+from OFS.PropertyManager import PropertyManager
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 from zope.interface import Interface
 
@@ -52,6 +53,15 @@ class SessionAuthHelper(BasePlugin):
     meta_type = 'Session Auth Helper'
     zmi_icon = 'fas fa-fingerprint'
     security = ClassSecurityInfo()
+    clear_session_on_login = False
+
+    _properties = (
+        PropertyManager._properties +
+        ({'id': 'clear_session_on_login',
+          'label': 'Clear session data at login boundary',
+          'type': 'boolean',
+          'mode': 'rw'},)
+    )
 
     def __init__(self, id, title=None):
         self._setId(id)
@@ -77,8 +87,10 @@ class SessionAuthHelper(BasePlugin):
                 name, password = login_pw
                 creds['login'] = name
                 creds['password'] = password
-                request.SESSION.set('__ac_name', name)
-                request.SESSION.set('__ac_password', password)
+
+                # Put the newly discovered credentials into the user session
+                self.updateCredentials(
+                    request, request.RESPONSE, name, password)
 
         if creds:
             creds['remote_host'] = request.get('REMOTE_HOST', '')
@@ -93,7 +105,11 @@ class SessionAuthHelper(BasePlugin):
     @security.private
     def updateCredentials(self, request, response, login, new_password):
         """ Respond to change of credentials. """
-        request.SESSION.set('__ac_name', login)
+        if request.SESSION.get('__ac_name') != login:
+            # This is a new session
+            if self.clear_session_on_login:
+                request.SESSION.clear()
+            request.SESSION.set('__ac_name', login)
         request.SESSION.set('__ac_password', new_password)
 
     @security.private

--- a/src/Products/PluggableAuthService/plugins/tests/test_SessionAuthHelper.py
+++ b/src/Products/PluggableAuthService/plugins/tests/test_SessionAuthHelper.py
@@ -13,9 +13,6 @@
 ##############################################################################
 import unittest
 
-from zope.component import adapter
-from zope.component import provideHandler
-
 from ...tests.conformance import ICredentialsResetPlugin_conformance
 from ...tests.conformance import ICredentialsUpdatePlugin_conformance
 from ...tests.conformance import ILoginPasswordHostExtractionPlugin_conformance

--- a/src/Products/PluggableAuthService/plugins/tests/test_SessionAuthHelper.py
+++ b/src/Products/PluggableAuthService/plugins/tests/test_SessionAuthHelper.py
@@ -1,0 +1,167 @@
+##############################################################################
+#
+# Copyright (c) 2025 Zope Foundation and Contributors
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this
+# distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+import unittest
+
+from zope.component import adapter
+from zope.component import provideHandler
+
+from ...tests.conformance import ICredentialsResetPlugin_conformance
+from ...tests.conformance import ICredentialsUpdatePlugin_conformance
+from ...tests.conformance import ILoginPasswordHostExtractionPlugin_conformance
+from ...tests.test_PluggableAuthService import FauxResponse
+from ...tests.test_PluggableAuthService import FauxSession
+
+
+class FauxHTTPRequest:
+
+    def __init__(self, name=None, password=None):
+        self._name = name
+        self._password = password
+        self.RESPONSE = FauxResponse()
+        self.SESSION = FauxSession()
+
+    def _authUserPW(self):
+        if self._name is None:
+            return None
+
+        return self._name, self._password
+
+    def get(self, name, default=None):
+        return getattr(self, name, default)
+
+
+class SessionAuthHelperTests(unittest.TestCase,
+                             ILoginPasswordHostExtractionPlugin_conformance,
+                             ICredentialsResetPlugin_conformance,
+                             ICredentialsUpdatePlugin_conformance):
+
+    def _getTargetClass(self):
+        from ...plugins.SessionAuthHelper import SessionAuthHelper
+
+        return SessionAuthHelper
+
+    def _makeOne(self, id='test', *args, **kw):
+        return self._getTargetClass()(id=id, *args, **kw)
+
+    def test_extractCredentials_no_creds(self):
+        helper = self._makeOne()
+        request = FauxHTTPRequest()
+
+        self.assertEqual(helper.extractCredentials(request), {})
+
+    def test_extractCredentials_form_creds(self):
+        helper = self._makeOne()
+        request = FauxHTTPRequest(name='foo', password='b:ar')
+
+        self.assertFalse(request.SESSION)
+        self.assertEqual(helper.extractCredentials(request),
+                         {'login': 'foo',
+                          'password': 'b:ar',
+                          'remote_host': '',
+                          'remote_address': ''})
+        self.assertEqual(request.SESSION['__ac_name'], 'foo')
+        self.assertEqual(request.SESSION['__ac_password'], 'b:ar')
+
+    def test_extractCredentials_session_creds(self):
+        helper = self._makeOne()
+        request = FauxHTTPRequest()
+        request.SESSION['__ac_name'] = 'foo'
+        request.SESSION['__ac_password'] = 'b:ar'
+
+        self.assertEqual(helper.extractCredentials(request),
+                         {'login': 'foo',
+                          'password': 'b:ar',
+                          'remote_host': '',
+                          'remote_address': ''})
+        self.assertEqual(request.SESSION['__ac_name'], 'foo')
+        self.assertEqual(request.SESSION['__ac_password'], 'b:ar')
+
+    def test_resetCredentials(self):
+        helper = self._makeOne()
+        request = FauxHTTPRequest()
+        request.SESSION['__ac_name'] = 'foo'
+        request.SESSION['__ac_password'] = 'b:ar'
+
+        helper.resetCredentials(request, request.RESPONSE)
+        self.assertFalse(request.SESSION.get('__ac_name'))
+        self.assertFalse(request.SESSION.get('__ac_password'))
+        self.assertFalse(helper.extractCredentials(request))
+
+    def test_updateCredentials_empty_session(self):
+        helper = self._makeOne()
+        request = FauxHTTPRequest()
+
+        self.assertFalse(request.SESSION)
+        request.SESSION['random_key'] = '123'
+        helper.updateCredentials(request, request.RESPONSE, 'foo', 'b:ar')
+        self.assertEqual(request.SESSION['__ac_name'], 'foo')
+        self.assertEqual(request.SESSION['__ac_password'], 'b:ar')
+        self.assertEqual(request.SESSION['random_key'], '123')
+        self.assertEqual(helper.extractCredentials(request),
+                         {'login': 'foo',
+                          'password': 'b:ar',
+                          'remote_host': '',
+                          'remote_address': ''})
+
+    def test_updateCredentials_existing_session(self):
+        helper = self._makeOne()
+        request = FauxHTTPRequest()
+        request.SESSION['__ac_name'] = 'foo'
+        request.SESSION['__ac_password'] = 'b:ar'
+        request.SESSION['random_key'] = '123'
+
+        helper.updateCredentials(request, request.RESPONSE, 'foo', 'b:az')
+        self.assertEqual(request.SESSION['__ac_name'], 'foo')
+        self.assertEqual(request.SESSION['__ac_password'], 'b:az')
+        self.assertEqual(request.SESSION['random_key'], '123')
+        self.assertEqual(helper.extractCredentials(request),
+                         {'login': 'foo',
+                          'password': 'b:az',
+                          'remote_host': '',
+                          'remote_address': ''})
+
+    def test_updateCredentials_existing_session_new_login(self):
+        # If the login name changes a new login session is assumed.
+        helper = self._makeOne()
+        request = FauxHTTPRequest()
+        request.SESSION['__ac_name'] = 'foo'
+        request.SESSION['__ac_password'] = 'b:ar'
+        request.SESSION['random_key'] = '123'
+
+        helper.updateCredentials(request, request.RESPONSE, 'bar', 'b:az')
+        self.assertEqual(request.SESSION['__ac_name'], 'bar')
+        self.assertEqual(request.SESSION['__ac_password'], 'b:az')
+        self.assertEqual(request.SESSION['random_key'], '123')
+        self.assertEqual(helper.extractCredentials(request),
+                         {'login': 'bar',
+                          'password': 'b:az',
+                          'remote_host': '',
+                          'remote_address': ''})
+
+    def test_updateCredentials_clears_session(self):
+        helper = self._makeOne()
+        helper.clear_session_on_login = True  # Turn on clearing session
+        request = FauxHTTPRequest()
+        request.SESSION['random_key'] = '123'
+
+        helper.updateCredentials(request, request.RESPONSE, 'bar', 'b:az')
+        self.assertEqual(request.SESSION['__ac_name'], 'bar')
+        self.assertEqual(request.SESSION['__ac_password'], 'b:az')
+        with self.assertRaises(KeyError):
+            request.SESSION['random_key']
+        self.assertEqual(helper.extractCredentials(request),
+                         {'login': 'bar',
+                          'password': 'b:az',
+                          'remote_host': '',
+                          'remote_address': ''})

--- a/src/Products/PluggableAuthService/tests/test_PluggableAuthService.py
+++ b/src/Products/PluggableAuthService/tests/test_PluggableAuthService.py
@@ -255,6 +255,12 @@ class DummyNotCompetentPlugin(DummyPlugin):
         return self.type
 
 
+class FauxSession(dict):
+
+    def set(self, name, value):
+        return self.__setitem__(name, value)
+
+
 class FauxRequest:
 
     form = property(lambda self: self)
@@ -265,6 +271,7 @@ class FauxRequest:
         self._dict = {}
         self._dict.update(kw)
         self._held = []
+        self.SESSION = FauxSession()
 
     def get(self, key, default=None):
 
@@ -275,7 +282,11 @@ class FauxRequest:
 
     def _authUserPW(self):
         form = self.get('form')
-        return (form.get('login'), form.get('password'))
+        login, pw = (form.get('login'), form.get('password'))
+        if login and pw:
+            return (login, pw)
+
+        return None
 
     def __getitem__(self, key):
 


### PR DESCRIPTION
Add property to clear session data at login boundary to the session auth
helper. This property defaults to ``False`` to preserve the current behavior.
Clearing session data during login helps mitigate session fixation attacks:
https://owasp.org/www-community/attacks/Session_fixation