### PR TITLE
Drop Python 3.9, add Python 3.14, convert to PEP 420

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/zope-product
 #
 # EditorConfig Configuration file, for more details see:
-# http://EditorConfig.org
+# https://EditorConfig.org
 # EditorConfig is a convention description, that could be interpreted
 # by multiple editors to enforce common coding conventions for specific
 # file types

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,10 +21,10 @@ jobs:
     name: linting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v6
       with:
-        python-version: 3.x
+        python-version: '3.13'
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  #v3.0.1
       with:
         extra_args: --all-files --show-diff-on-failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,11 +24,11 @@ jobs:
         config:
         # [Python version, tox env]
         - ["3.11", "release-check"]
-        - ["3.9", "py39"]
         - ["3.10", "py310"]
         - ["3.11", "py311"]
         - ["3.12", "py312"]
         - ["3.13", "py313"]
+        - ["3.14", "py314"]
         - ["3.11", "docs"]
         - ["3.11", "coverage"]
         - ["3.11",   "py311-ip_range"]
@@ -37,17 +37,18 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Install uv + caching
-      uses: astral-sh/setup-uv@v5
+      # astral/setup-uv@7.1.3
+      uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3
       with:
         enable-cache: true
         cache-dependency-glob: |
           setup.*
           tox.ini
-        python-version: ${{ matrix.matrix.config[0] }}
+        python-version: ${{ matrix.config[0] }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Test
       if: ${{ !startsWith(runner.os, 'Mac') }}

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/zope-product
 [meta]
 template = "zope-product"
-commit-id = "a0de4e93"
+commit-id = "9fcd3d67"
 
 [python]
 with-pypy = false
@@ -21,6 +21,7 @@ known_first_party = "Products.PluginRegistry, Products.StandardCacheManagers, Pr
 [check-manifest]
 additional-ignores = [
     "docs/_build/html/_sources/api/*",
+    "docs/_build/html/_static/scripts/*",
     ]
 
 [manifest]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 minimum_pre_commit_version: '3.6'
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: "6.0.1"
+    rev: "7.0.0"
     hooks:
     - id: isort
   - repo: https://github.com/hhatto/autopep8
@@ -12,16 +12,16 @@ repos:
     - id: autopep8
       args: [--in-place, --aggressive, --aggressive]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
+    rev: v3.21.0
     hooks:
     - id: pyupgrade
-      args: [--py39-plus]
+      args: [--py310-plus]
   - repo: https://github.com/isidentical/teyit
     rev: 0.4.3
     hooks:
     - id: teyit
   - repo: https://github.com/PyCQA/flake8
-    rev: "7.1.2"
+    rev: "7.3.0"
     hooks:
     - id: flake8
       additional_dependencies:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,18 +4,16 @@ Change Log
 4.0 (unreleased)
 ----------------
 
+- Switch to PEP 420 native namespace.
+
+- Add support for Python 3.12, 3.13 and 3.14.
+
+- Drop support for Python 3.7, 3.8 and 3.9.
+
 - Add property to clear session data at login boundary to the session auth
   helper. This property defaults to ``False`` to preserve the current behavior.
   Clearing session data during login helps mitigate session fixation attacks:
   https://owasp.org/www-community/attacks/Session_fixation
-
-- Add support for Python 3.13.
-
-- Drop support for Python 3.8.
-
-- Add support for Python 3.12.
-
-- Drop support for Python 3.7.
 
 - Remove traces of long-deprecated 'Shared' roles support.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,24 +11,26 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import datetime
 import os
+import sys
+from importlib.metadata import distribution
 
 
-parent = os.path.dirname(os.path.dirname(__file__))
-parent_dir = os.path.abspath(parent)
-with open(os.path.join(parent_dir, 'version.txt')) as version_file:
-    pkg_version = version_file.read().strip()
+year = datetime.datetime.now().year
+sys.path.append(os.path.abspath('../src'))
+rqmt = distribution('Products.PluggableAuthService')
 
 # -- Project information -----------------------------------------------------
 
 project = 'Products.PluggableAuthService'
-copyright = '2004-2018 Zope Foundation and Contributors'
+copyright = f'2004-{year} Zope Foundation and Contributors'
 author = 'Zope Foundation and Contributors'
 
 # The short X.Y version
-version = pkg_version.replace('.dev0', '')
+version = '%s.%s' % tuple(rqmt.version.split('.')[:2])
 # The full version, including alpha/beta/rc tags
-release = pkg_version
+release = rqmt.version
 
 # -- General configuration ---------------------------------------------------
 
@@ -75,7 +77,7 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'default'
+html_theme = 'furo'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 Sphinx
 repoze.sphinx.autointerface
+furo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [build-system]
 requires = [
-    "setuptools == 75.8.2",
+    "setuptools >= 78.1.1,< 81",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ ignore =
     .meta.toml
     docs/_build/html/_sources/*
     docs/_build/html/_sources/api/*
+    docs/_build/html/_static/scripts/*
 
 [isort]
 force_single_line = True

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -37,11 +36,11 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Zope Public License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Software Development',
         'Topic :: System :: Systems Administration'
         ' :: Authentication/Directory',
@@ -59,14 +58,8 @@ setup(
                     'Products.PluggableAuthService'),
     },
     license='ZPL-2.1 (http://www.zope.org/Resources/License/ZPL-2.1)',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    include_package_data=True,
-    namespace_packages=['Products'],
-    zip_safe=False,
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     install_requires=[
-        'setuptools',
         'Zope >= 5',
         'AccessControl >= 4.0a1',
         'Products.PluginRegistry >= 1.6',
@@ -76,7 +69,7 @@ setup(
     ],
     extras_require={
         'ip_range': ['IPy'],
-        'docs': ['Sphinx', 'repoze.sphinx.autointerface'],
+        'docs': ['Sphinx', 'repoze.sphinx.autointerface', 'furo'],
     },
     entry_points="""
     [zope2.initialize]

--- a/src/Products/__init__.py
+++ b/src/Products/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,11 @@ minversion = 3.18
 envlist =
     release-check
     lint
-    py39
     py310
     py311
     py312
     py313
+    py314
     docs
     coverage
     py311-ip_range
@@ -17,7 +17,7 @@ envlist =
 [testenv]
 skip_install = true
 deps =
-    setuptools == 75.8.2
+    setuptools >= 78.1.1,< 81
     zc.buildout
     wheel
 setenv =
@@ -45,7 +45,7 @@ description = ensure that the distribution is ready to release
 basepython = python3
 skip_install = true
 deps =
-    setuptools == 75.8.2
+    setuptools >= 78.1.1,< 81
     wheel
     twine
     build
@@ -55,7 +55,7 @@ deps =
 commands_pre =
 commands =
     check-manifest
-    check-python-versions --only setup.py,tox.ini,.github/workflows/tests.yml
+    check-python-versions --only pyproject.toml,setup.py,tox.ini,.github/workflows/tests.yml
     python -m build --sdist --no-isolation
     twine check dist/*
 


### PR DESCRIPTION
- Switch to PEP 420 native namespace.
- Add support for Python 3.14.
- Drop support for Python 3.9.